### PR TITLE
Added MSWin64 build script

### DIFF
--- a/dist/MSWin64/biber.files
+++ b/dist/MSWin64/biber.files
@@ -1,0 +1,16 @@
+../../data/biber-tool.conf;lib/Biber/biber-tool.conf
+../../data/schemata/config.rnc;lib/Biber/config.rnc
+../../data/schemata/config.rng;lib/Biber/config.rng
+../../data/schemata/bcf.rnc;lib/Biber/bcf.rnc
+../../data/schemata/bcf.rng;lib/Biber/bcf.rng
+../../data/schemata/biblatexml.rnc;lib/Biber/biblatexml.rnc
+../../data/schemata/biblatexml.rng;lib/Biber/biblatexml.rng
+../../lib/Biber/LaTeX/recode_data.xml;lib/Biber/LaTeX/recode_data.xml
+../../data/bcf.xsl;lib/Biber/bcf.xsl
+../../data/latinkeys.txt;lib/Unicode/Collate/latinkeys.txt
+C:/strawberry/perl/lib/Unicode/Collate/Locale;lib/Unicode/Collate/Locale
+C:/strawberry/perl/lib/Unicode/Collate/CJK;lib/Unicode/Collate/CJK
+C:/strawberry/perl/lib/Unicode/Collate/allkeys.txt;lib/Unicode/Collate/allkeys.txt
+C:/strawberry/perl/lib/Unicode/Collate/keys.txt;lib/Unicode/Collate/keys.txt
+C:/strawberry/perl/vendor/lib/Mozilla/CA/cacert.pem;lib/Mozilla/CA/cacert.pem
+C:/strawberry/perl/site/lib/Business/ISBN/RangeMessage.xml;lib/Business/ISBN/RangeMessage.xml

--- a/dist/MSWin64/build.bat
+++ b/dist/MSWin64/build.bat
@@ -1,0 +1,79 @@
+:: The COPY/DEL steps are so that the packed biber main script is not
+:: called "biber" as on case-insensitive file systems, this clashes with
+:: the Biber lib directory and generates a (harmless) warning on first run.
+
+:: XML::LibXSLT has a workaround for LibXSLT.dll conflicting with libxslt.dll on
+:: windows due to case-insensitivity. The Makefile.PL for XML::LibXSLT forces its
+:: .dll to end in ".xs.dll" which avoids the conflict but breaks when packaged with pp.
+:: Since strawberry perl includes its own libxslt with a non-default name, it is therefore
+:: safe to use the default XML::LibXSLT .dll name which does work when packed with pp.
+:: To do this, you have to install your own XML::LibXSLT in strawberry perl:
+:: edit the Makefile.PL, line 195 or thereabouts and change it to:
+::
+::     $config{DLEXT} = 'dll' if ($is_Win32);
+::
+:: then build and install as usual (this seems ok with the included
+:: XML::LibXSLT with strawberry perl 5.16 and 5.18 for some reason)
+
+:: Have to explicitly include the Input* modules as the names of these are dynamically
+:: constructed in the code so Par::Packer can't auto-detect them.
+:: Same with some of the output modules.
+
+SET perldir=C:\strawberry\
+
+COPY C:\strawberry\perl\site\bin\biber %TEMP%\biber-MSWIN64
+
+SET PAR_VERBATIM=1
+
+CALL pp ^
+  --compress=6 ^
+  --module=deprecate ^
+  --module=Biber::Input::file::bibtex ^
+  --module=Biber::Input::file::biblatexml ^
+  --module=Biber::Input::file::ris ^
+  --module=Biber::Input::file::zoterordfxml ^
+  --module=Biber::Input::file::endnotexml ^
+  --module=Biber::Output::dot ^
+  --module=Biber::Output::bbl ^
+  --module=Biber::Output::bibtex ^
+  --module=Biber::Output::biblatexml ^
+  --module=Pod::Simple::TranscodeSmart ^
+  --module=Pod::Simple::TranscodeDumb ^
+  --module=Encode::Byte ^
+  --module=Encode::CN ^
+  --module=Encode::CJKConstants ^
+  --module=Encode::EBCDIC ^
+  --module=Encode::Encoder ^
+  --module=Encode::GSM0338 ^
+  --module=Encode::Guess ^
+  --module=Encode::JP ^
+  --module=Encode::KR ^
+  --module=Encode::MIME::Header ^
+  --module=Encode::Symbol ^
+  --module=Encode::TW ^
+  --module=Encode::Unicode ^
+  --module=Encode::Unicode::UTF7 ^
+  --module=Encode::EUCJPASCII ^
+  --module=Encode::JIS2K ^
+  --module=Encode::HanExtra ^
+  --module=IO::Socket::SSL ^
+  --module=File::Find::Rule ^
+  --link=C:\WINDOWS\system32\libbtparse.dll ^
+  --link=d:\apps\c\bin\libxslt-1_.dll ^
+  --link=d:\apps\c\bin\libexslt-0_.dll ^
+  --link=d:\apps\c\bin\zlib1_.dll ^
+  --link=d:\apps\c\bin\libxml2-2_.dll ^
+  --link=d:\apps\c\bin\libiconv-2_.dll ^
+  --link=d:\apps\c\bin\ssleay32_.dll ^
+  --link=d:\apps\c\bin\libeay32_.dll ^
+  --link=d:\apps\c\bin\liblzma-5_.dll ^
+  --link=C:\strawberry\c\bin\libxml2-2__.dll ^
+  --link=C:\strawberry\c\bin\libiconv-2__.dll ^
+  --link=C:\strawberry\c\bin\liblzma-5__.dll ^
+  --link=C:\strawberry\c\bin\zlib1__.dll ^
+  --addlist=biber.files ^
+  --cachedeps=scancache ^
+  --output=biber-MSWIN64.exe ^
+  %TEMP%\biber-MSWIN64
+
+DEL %TEMP%\biber-MSWIN64


### PR DESCRIPTION
This is the build script for MSWin64 platform. I had to add some more libraries to the pp command line with --link to get it to work properly.

You will need strawberry perl 64bit. I tested it with version 5.18.2.2. If you don't have the 64bit version, get the zip version, move the 32bit folder to the side and extract the 64bit version into c:\strawberry. Run "relocation.pl.bat" and "update_env.pl.bat" to finish installing it. Install all dependencies for biber and install it (Encode::JIS2K refused to install because it could not find enc2xs: fix it by providing a fixed path for $enc2xs variable in Makefile.pl and then manually installing it). I also ran upx with option --lzma on the entire perl folder recursively to get the biber executable file size down. This should be done before installing PAR::Packer, because it seems to cache some libraries upon install which cannot be packed afterwards. Last, make sure the paths in the biber build script are correct and run it. My executable ended up being 14.7 MB big.

To get the 32bit perl version back, simply move it back to the original folder and run "relocation.pl.bat" and "update_env.pl.bat".
