### PR TITLE
Drop unneeded builddeps

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -38,10 +38,7 @@ my $builder = $class->new(
                         },
     add_to_cleanup      => [ 'biber-*' ],
     configure_requires => { 'Module::Build' => 0.38 },
-    build_requires => {
-        'Config::AutoConf' => '0.15',
-        'ExtUtils::LibBuilder' => '0.02'
-    },
+    build_requires => { },
     requires => {
         'autovivification' => 0,
         'Data::Dump' => 0,


### PR DESCRIPTION
    These were noted during a package review for Fedora:
    https://bugzilla.redhat.com/show_bug.cgi?id=1165620#c13
