### PR TITLE
Fix regular expression that removes macros

### DIFF
--- a/lib/Biber/Utils.pm
+++ b/lib/Biber/Utils.pm
@@ -273,7 +273,7 @@ sub strip_noinit {
     $string =~ s/$re//gxms;
   }
   # remove latex macros (assuming they have only ASCII letters)
-  $string =~ s/\\[A-Za-z]+\s*\{?([^\}]+)\}?/$1/g;
+  $string =~ s{\\[A-Za-z]+\s*(\{([^\}]*)?\})?}{defined($2)?$2:q{}}eg;
   return $string;
 }
 

--- a/t/utils.t
+++ b/t/utils.t
@@ -5,7 +5,7 @@ use utf8;
 no warnings 'utf8' ;
 use open qw/:std :utf8/;
 
-use Test::More tests => 81;
+use Test::More tests => 83;
 use Test::Differences;
 unified_diff;
 
@@ -170,3 +170,5 @@ eq_or_diff([split_xsv('"family={Something, here}", given=b')], ['family={Somethi
 
 eq_or_diff(strip_noinit('\texttt{freedesktop.org}'), 'freedesktop.org', 'Name strip - 1');
 eq_or_diff(strip_noinit('\texttt freedesktop.org'), 'freedesktop.org', 'Name strip - 2');
+eq_or_diff(strip_noinit('{\texttt freedesktop.org}'), '{freedesktop.org}', 'Name strip - 3');
+eq_or_diff(strip_noinit('{C.\bibtexspatium A.}'), '{C.A.}', 'Name strip - 4');


### PR DESCRIPTION
The current implementation removes all braces after a macro.
So `{ some text \macro ... }` would result in invalid `{ some text ...`.

I came across this issue when biber crashed on the following entry
```
@Book{ahrens91:_ordo_mensur,
  Title                    = {Ordo et Mensura},
  Editor                   = {Ahrens, Dieter and Rottl{\"a}nder, {C.\bibtexspatium A.}},
  Publisher                = {Scripta mercaturae Verlag},
  Year                     = {1991},
  Address                  = {St. Katharinen}
}
```

Note that this does not always lead biber to crash. It somehow depended on the preceding entries in the BibTeX file. 

The old regex changed  `{C.\bibtexspatium A.}` into `{C.\bibtexspatium A.`.
