### PR TITLE
Add Zotero-Allowed-Request request header

### DIFF
--- a/lib/Biber/Utils.pm
+++ b/lib/Biber/Utils.pm
@@ -172,7 +172,8 @@ sub locate_data_file {
       # Pretend to be a browser otherwise some sites refuse the default LWP UA string
       $LWP::Simple::ua->agent('Mozilla/5.0');
 
-      my $retcode = LWP::Simple::getstore($source, $tf->filename);
+      my $retcode = LWP::Simple::getstore($source, $tf->filename,
+        "Zotero-Allowed-Request" => "1");
       unless (LWP::Simple::is_success($retcode)) {
         biber_error("Could not fetch '$source' (HTTP code: $retcode)");
       }


### PR DESCRIPTION
From 5.0.71 onwards, zotero requires Zotero-Allowed-Request:1 on GET requests with a browser-like user agent.