### PR TITLE
Krumeich/aarch64 linux musl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/*/scancache
 t/tdata/*.rng
 dist/build-env-cmds
 *_flymake*
+*~

--- a/dist/linux_aarch64-musl/build.sh
+++ b/dist/linux_aarch64-musl/build.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# For some reason, PAR::Packer on linux is clever and when processing link lines
+# resolves any symlinks but names the packed lib the same as the link name. This is
+# a good thing. This is a feature of PAR::Packer on ELF systems.
+
+# Have to be very careful about Perl modules with .so binary libraries as sometimes
+# (LibXML.so for example), they include RPATH which means that the PAR cache
+# is not searched first, even though it's at the top of LD_LIBRARY_PATH. So, the wrong
+# libraries will be found and things may well break. Strip any RPATH out of such libs
+# with "chrpath -d <lib>". Check for presence with "readelf -d <lib>".
+#
+# Check all perl binaries with:
+# for file in `find /usr/local/perl/lib* -name \*.so`; do echo $file >> /tmp/out ;readelf -d $file >> /tmp/out; done
+# and then grep the file for "RPATH"
+
+# Had to add /etc/ld.so.conf.d/biber.conf and put "/usr/local/perl/lib64" in there
+# and then run "sudo ldconfig" so that libbtparse.so is found. Doesn't really make
+# a difference to the build, just the running of Text::BibTeX itself.
+
+# Using a newer locally built libz and libxml2 (and rebuilt XML::LibXML) in /usr/local because
+# beginning with 32-bit Debian Wheezy, the older ones would segfault
+
+# Have to explicitly include the Input* modules as the names of these are dynamically
+# constructed in the code so Par::Packer can't auto-detect them
+# Same with some of the output modules.
+
+# Added libz as some linux distros like SUSE 11.3 have a slightly older zlib
+# which doesn't have gzopen64 in it.
+
+# Unicode::Collate is bundled with perl but is often updated and this is a critical module
+# for biber. There are some parts of this module which must be explicitly bundled by pp.
+# Unfortunately, updates to the module go into site_perl and we must bundle the right version
+# and so we check if there are any newer versions than came with the version of perl we are using
+# by looking to see if there is a site_perl directory for the module. If there is, we use that
+# version.
+
+declare -r perlv='5.32.0'
+declare ucpath="/usr/local/lib/perl5/site_perl/Unicode/Collate"
+
+# Unicode::Collate has a site_perl version so has been updated since this
+# perl was released
+if [ -d "/usr/local/perl/lib/site_perl/${perlv}/aarch64-linux-thread-multi/Unicode/Collate" ]
+then
+  ucpath="/usr/local/perl/lib/site_perl/${perlv}/aarch64-linux-thread-multi/Unicode/Collate"
+fi
+
+echo "USING Unicode::Collate at: ${ucpath}"
+
+PAR_VERBATIM=1 /usr/local/bin/pp \
+  --module=deprecate \
+  --module=Biber::Input::file::bibtex \
+  --module=Biber::Input::file::biblatexml \
+  --module=Biber::Output::dot \
+  --module=Biber::Output::bbl \
+  --module=Biber::Output::bblxml \
+  --module=Biber::Output::bibtex \
+  --module=Biber::Output::biblatexml \
+  --module=Pod::Simple::TranscodeSmart \
+  --module=Pod::Simple::TranscodeDumb \
+  --module=List::MoreUtils::XS \
+  --module=List::SomeUtils::XS \
+  --module=List::MoreUtils::PP \
+  --module=HTTP::Status \
+  --module=HTTP::Date \
+  --module=Encode:: \
+  --module=File::Find::Rule \
+  --module=IO::Socket::SSL \
+  --module=IO::String \
+  --module=PerlIO::utf8_strict \
+  --module=Text::CSV_XS \
+  --module=DateTime \
+  --link=/usr/local/lib/libbtparse.so \
+  --link=/usr/lib/libxml2.so.2 \
+  --link=/lib/libz.so.1 \
+  --link=/usr/lib/liblzma.so.5 \
+  --link=/usr/lib/libxslt.so.1 \
+  --link=/usr/lib/libexslt.so.0 \
+  --link=/usr/lib/libssl.so.1.1 \
+  --link=/usr/lib/libcrypto.so.1.1 \
+  --link=/usr/lib/libgcrypt.so.20 \
+  --link=/usr/lib/libgpg-error.so.0 \
+  --addfile="../../data/biber-tool.conf;lib/Biber/biber-tool.conf" \
+  --addfile="../../data/schemata/config.rnc;lib/Biber/config.rnc" \
+  --addfile="../../data/schemata/config.rng;lib/Biber/config.rng"\
+  --addfile="../../data/schemata/bcf.rnc;lib/Biber/bcf.rnc" \
+  --addfile="../../data/schemata/bcf.rng;lib/Biber/bcf.rng" \
+  --addfile="../../lib/Biber/LaTeX/recode_data.xml;lib/Biber/LaTeX/recode_data.xml" \
+  --addfile="../../data/bcf.xsl;lib/Biber/bcf.xsl" \
+  --addfile="${ucpath}/Locale;lib/Unicode/Collate/Locale" \
+  --addfile="${ucpath}/CJK;lib/Unicode/Collate/CJK" \
+  --addfile="${ucpath}/allkeys.txt;lib/Unicode/Collate/allkeys.txt" \
+  --addfile="${ucpath}/keys.txt;lib/Unicode/Collate/keys.txt" \
+  --addfile="/usr/local/share/perl5/site_perl/Mozilla/CA/cacert.pem" \
+  --addfile="/usr/local/lib/perl5/site_perl/PerlIO" \
+  --addfile="/usr/local/share/perl5/site_perl/Business/ISBN/RangeMessage.xml" \
+  --cachedeps=scancache \
+  --output=/opt/biber \
+  /usr/local/bin/biber

--- a/dist/linux_x86_64-musl/build.sh
+++ b/dist/linux_x86_64-musl/build.sh
@@ -36,7 +36,7 @@
 # version.
 
 declare -r perlv='5.32.0'
-declare ucpath="/usr/local/lib/perl5/5.32.0/Unicode/Collate"
+declare ucpath="/usr/local/lib/perl5/site_perl/Unicode/Collate"
 
 # Unicode::Collate has a site_perl version so has been updated since this
 # perl was released
@@ -91,9 +91,9 @@ PAR_VERBATIM=1 /usr/local/bin/pp \
   --addfile="${ucpath}/CJK;lib/Unicode/Collate/CJK" \
   --addfile="${ucpath}/allkeys.txt;lib/Unicode/Collate/allkeys.txt" \
   --addfile="${ucpath}/keys.txt;lib/Unicode/Collate/keys.txt" \
-  --addfile="/usr/local/lib/perl5/site_perl/5.32.0/Mozilla/CA/cacert.pem" \
-  --addfile="/usr/local/lib/perl5/5.32.0/PerlIO" \
-  --addfile="/usr/local/lib/perl5/site_perl/5.32.0/Business/ISBN/RangeMessage.xml" \
+  --addfile="/usr/local/share/perl5/site_perl/Mozilla/CA/cacert.pem" \
+  --addfile="/usr/local/lib/perl5/site_perl/PerlIO" \
+  --addfile="/usr/local/share/perl5/site_perl/Business/ISBN/RangeMessage.xml" \
   --cachedeps=scancache \
   --output=/opt/biber \
   /usr/local/bin/biber


### PR DESCRIPTION
This PR addresses two changes:

* Changed dir layout for MUSL build because of switch to a different Alpine base image
* Support for ARM64 architecture for a MUSL based Linux distribution (linux-aarch64-musl)

The new architecture is used when running Alpine Linux on a recent Raspberry Pi or when running Docker on an Apple Silicon Mac. The binary itself is produced by the build pipeline in https://github.com/krumeich/biber-alpine. This image is now a multi-arch image, i.e. you can use it on x86_64 and on aarch64.

I've tested the binary successfully against the test-dev file on SourceForge. I'd be willing to provide a build for linux-aarm64-musl in the future, in addition to the build I already contribute for linux-x86_64-musl. If it's alright with you, I'd add another directory on SourceForge so that we can add this platform to TeX Live, once 2.17 is released.

