### PR TITLE
Adapt to Perl 5.36

### DIFF
--- a/lib/Biber/Section.pm
+++ b/lib/Biber/Section.pm
@@ -429,7 +429,7 @@ sub add_everykey {
 
 sub del_everykeys {
   my $self = shift;
-  $self->{everykey} = undef
+  $self->{everykey} = undef;
   $self->{everykey_lc} = undef;
   return;
 }


### PR DESCRIPTION
A developmental release of Perl 5.36.0 fails to run tests with:

    $ perl -Ilib t/basic-misc.t
    1..72
    Can't modify undef operator in scalar assignment at lib/Biber/Section.pm line 433, near "undef;"
    Compilation failed in require at lib/Biber.pm line 24.
    BEGIN failed--compilation aborted at lib/Biber.pm line 24.
    Compilation failed in require at t/basic-misc.t line 11.
    BEGIN failed--compilation aborted at t/basic-misc.t line 11.
    # Looks like your test exited with 255 before it could output anything.

This is because of a missing semicolon between commands in
del_everykeys(). The new perl is more strict and raises a compile-time
error:

    $ perl -e '$a = undef $b = undef;'
    Can't modify undef operator in scalar assignment at -e line 1, near "undef;"
    Execution of -e aborted due to compilation errors.