### PR TITLE
Added 'output_legacy_dates' to 'config.rng'

### DIFF
--- a/data/schemata/config.rng
+++ b/data/schemata/config.rng
@@ -358,6 +358,14 @@
           </element>
         </optional>
         <optional>
+          <element name="output_legacy_dates">
+            <choice>
+              <value>0</value>
+              <value>1</value>
+            </choice>
+          </element>
+        </optional>
+        <optional>
           <element name="output_listsep">
             <text/>
           </element>


### PR DESCRIPTION
I need to use the legacy format for year and month, so I was glad to find the `--output-legacy-dates` option.

When I check my `biber.conf` with `biber --tool --validate-config`, it fails as there is no entry in `config.rng` for it yet. This PR adds the missing entry.